### PR TITLE
Move client specific tick code out of global mixin

### DIFF
--- a/src/main/java/net/arathain/malazan/MalazanClient.java
+++ b/src/main/java/net/arathain/malazan/MalazanClient.java
@@ -1,24 +1,23 @@
 package net.arathain.malazan;
 
-import net.arathain.malazan.common.render.FlareRenderer;
-import net.arathain.malazan.common.render.PortalRenderer;
-import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityRendererRegistry;
-import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.nbt.NbtCompound;
-import net.minecraft.nbt.NbtElement;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.particle.ParticleTypes;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-import org.lwjgl.glfw.GLFW;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityRendererRegistry;
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
 
-import java.util.Objects;
 import java.util.Random;
+
+import io.netty.buffer.Unpooled;
+import net.arathain.malazan.common.render.FlareRenderer;
+import net.arathain.malazan.common.render.PortalRenderer;
+import org.lwjgl.glfw.GLFW;
 
 public class MalazanClient implements ClientModInitializer {
 
@@ -65,5 +64,24 @@ public class MalazanClient implements ClientModInitializer {
                         GLFW.GLFW_KEY_X, // The keycode of the key
                         "category.malazan.spells" // The translation key of the keybinding's category.
                 ));
+        }
+
+        public static void tickPlayer(PlayerEntity player, Random random) {
+            if (spellbind1.isPressed()) {
+                PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
+                passedData.writeBlockPos(player.getBlockPos());
+
+                if (random.nextBoolean()) {
+                    ClientSidePacketRegistry.INSTANCE.sendToServer(Malazan.TELAS_KEYBIND_UNO, passedData);
+                }
+            }
+            if (spellbind2.isPressed()) {
+                PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
+                passedData.writeBlockPos(player.getBlockPos());
+
+                if (random.nextBoolean()) {
+                    ClientSidePacketRegistry.INSTANCE.sendToServer(Malazan.TELAS_KEYBIND_DOS, passedData);
+                }
+            }
         }
 }

--- a/src/main/java/net/arathain/malazan/mixin/PlayerEntityMixin.java
+++ b/src/main/java/net/arathain/malazan/mixin/PlayerEntityMixin.java
@@ -27,24 +27,7 @@ public abstract class PlayerEntityMixin extends LivingEntity {
     public void tick(CallbackInfo ci) {
 
         if (world.isClient()) {
-            if(MalazanClient.spellbind1.isPressed()){
-                PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
-                passedData.writeBlockPos(this.getBlockPos());
-
-                if (this.random.nextBoolean()) {
-                    ClientSidePacketRegistry.INSTANCE.sendToServer(Malazan.TELAS_KEYBIND_UNO, passedData);
-                }
-            }
-            if(MalazanClient.spellbind2.isPressed()){
-                PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
-                passedData.writeBlockPos(this.getBlockPos());
-
-                if (this.random.nextBoolean()) {
-                    ClientSidePacketRegistry.INSTANCE.sendToServer(Malazan.TELAS_KEYBIND_DOS, passedData);
-                }
-            }
-
-
+            MalazanClient.tickPlayer((PlayerEntity) (Object) this, this.random);
         } else {
             if (this.getEntityWorld().getServer() != null && this.getEntityWorld() == this.getEntityWorld().getServer().getWorld(Malazan.TELAS_WORLD_KEY)) {
                 this.setOnFireFor(1);


### PR DESCRIPTION
The keybinding code causes issues with the mixin applying on a dedicated server. I moved it out to the next best place I thought of, this can probably be put somewhere better but I haven't ever actually encountered this myself so I don't know what I would have done in such a situation in my own mods, and I didn't want to create a new class just for this.
